### PR TITLE
Add io_buffer_size config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ For Windows distributions one of the `.exe` versions:
 The miner needs a **config.yaml** file.</br>
 Please download from the corresponding release.
 
+`io_buffer_size` lets you tune how much data is read from disk per task. The
+default of 4&nbsp;MiB works well for most drives but you may lower it for slow
+USB devices.
+
 ### Running
 Be sure to have the config file on the same folder of your binary.</br>
 

--- a/config.yaml
+++ b/config.yaml
@@ -16,6 +16,7 @@ hdd_wakeup_after: 240                 # default 240s
 cpu_threads: 4                        # default 4 (0=auto: number of logical cpu cores)
 cpu_worker_task_count: 4              # default 4 (0=GPU only)
 cpu_nonces_per_cache: 65536           # default 65536
+io_buffer_size: 4194304               # default 4MiB
 cpu_thread_pinning: false             # default false
 
 gpu_threads: 0                        # default 0 (=GPU off)

--- a/src/miner.rs
+++ b/src/miner.rs
@@ -338,7 +338,9 @@ impl Miner {
         let buffer_count = cpu_buffer_count;
         #[cfg(feature = "opencl")]
         let buffer_count = cpu_buffer_count + gpu_buffer_count;
-        let buffer_size_cpu = cfg.cpu_nonces_per_cache * SCOOP_SIZE as usize;
+
+        let cpu_nonces_per_cache = cfg.io_buffer_size / SCOOP_SIZE as usize;
+        let buffer_size_cpu = cpu_nonces_per_cache * SCOOP_SIZE as usize;
         let (tx_empty_buffers, rx_empty_buffers) =
             crossbeam_channel::bounded(buffer_count as usize);
         let (tx_read_replies_cpu, rx_read_replies_cpu) =


### PR DESCRIPTION
## Summary
- add `io_buffer_size` option in configuration with a 4 MiB default
- derive nonces per cache from the new option during miner startup
- mention the new option in README
- show example in `config.yaml`

## Testing
- `cargo test` *(fails: could not download crate index)*