### PR TITLE
Handle USB plots

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ For Windows distributions one of the `.exe` versions:
 ### Config
 
 The miner needs a **config.yaml** file.</br>
-Please download from the corresponding release.
+Please download from the corresponding release. Direct I/O will be
+automatically disabled for plot directories residing on USB drives.
 
 ### Running
 Be sure to have the config file on the same folder of your binary.</br>

--- a/config.yaml
+++ b/config.yaml
@@ -10,7 +10,7 @@ url: 'https://pool.burstcoin.ro'      # mainnet pool
 #url: 'http://localhost:6876'         # solo mining testnet
 
 hdd_reader_thread_count: 0            # default 0 (=auto: number of disks)
-hdd_use_direct_io: true               # default true
+hdd_use_direct_io: true               # default true (ignored on USB drives)
 hdd_wakeup_after: 240                 # default 240s
 
 cpu_threads: 4                        # default 4 (0=auto: number of logical cpu cores)


### PR DESCRIPTION
## Summary
- detect bus type for plot directories
- disable direct I/O when on USB drives
- log USB plots when scanning
- document USB handling in README and config

## Testing
- `cargo test` *(fails: could not fetch crates.io index)*