### PR TITLE
Fix compile warnings and gating for async_io

### DIFF
--- a/src/future/prio_retry.rs
+++ b/src/future/prio_retry.rs
@@ -13,7 +13,6 @@ use std::{
 
 use futures_core::Stream;
 use futures_core::Future;
-use futures_util::stream::StreamExt;
 use pin_project::pin_project;
 use tokio::time::{self, Duration, Instant, Sleep};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,7 @@ mod ocl;
 use crate::config::load_cfg;
 use crate::miner::Miner;
 use clap::{Arg, Command};
+#[cfg(feature = "opencl")]
 use std::process;
 
 cfg_if! {

--- a/src/miner.rs
+++ b/src/miner.rs
@@ -31,7 +31,6 @@ use std::sync::{Arc, Mutex};
 //use std::sync::Arc;
 //use tokio::sync::Mutex;
 use std::thread;
-use std::time::Duration;
 use std::u64;
 use stopwatch::Stopwatch;
 use tokio::runtime::Handle;
@@ -233,7 +232,8 @@ fn scan_plots(
         .drain()
         .map(|(drive_id, mut plots)| {
             plots.sort_by_key(|p| {
-                let m = p.lock().unwrap().fh.metadata().unwrap();
+                let p = p.lock().unwrap();
+                let m = std::fs::metadata(&p.path).unwrap();
                 -FileTime::from_last_modification_time(&m).unix_seconds()
             });
             (drive_id, Arc::new(plots))

--- a/src/plot.rs
+++ b/src/plot.rs
@@ -168,7 +168,8 @@ impl Plot {
         })
     }
 
-    pub fn prepare(&mut self, scoop: u32) -> io::Result<u64> {
+#[cfg(not(feature = "async_io"))]
+pub fn prepare(&mut self, scoop: u32) -> io::Result<u64> {
         self.read_offset = 0;
         let nonces = self.meta.nonces;
         let mut seek_addr = u64::from(scoop) * nonces as u64 * SCOOP_SIZE;
@@ -208,6 +209,7 @@ impl Plot {
         self.fh.seek(SeekFrom::Start(seek_addr)).await
     }
 
+#[cfg(not(feature = "async_io"))]
     pub fn read(&mut self, bs: &mut Vec<u8>, scoop: u32) -> Result<(usize, u64, bool), io::Error> {
         let read_offset = self.read_offset;
         let buffer_cap = bs.capacity();
@@ -288,6 +290,7 @@ impl Plot {
         Ok((bytes_to_read, start_nonce, finished))
     }
 
+#[cfg(not(feature = "async_io"))]
     pub fn seek_random(&mut self) -> io::Result<u64> {
         let mut rng = thread_rng();
         let rand_scoop = rng.gen_range(0, SCOOPS_IN_NONCE);

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -118,7 +118,6 @@ impl RequestHandler {
                             error!("can't send submission params");
                         }
                     }
-                    _ => {}
                 }
             }
         });


### PR DESCRIPTION
## Summary
- remove unused imports and unreachable pattern
- gate sync Plot methods to non-async builds
- use synchronous metadata lookup when scanning plots
- conditionally import `std::process` only for opencl builds

## Testing
- `cargo check` *(fails: failed to download from crates.io)*