### PR TITLE
Fix async build issues

### DIFF
--- a/src/cpu_worker.rs
+++ b/src/cpu_worker.rs
@@ -120,6 +120,9 @@ pub fn hash(
         let mut offset: u64 = 0;
 
         let bs = buffer.get_buffer_for_writing();
+#[cfg(feature = "async_io")]
+        let bs = bs.blocking_lock();
+#[cfg(not(feature = "async_io"))]
         let bs = bs.lock().unwrap();
 
         #[cfg(feature = "simd_avx512f")]

--- a/src/miner.rs
+++ b/src/miner.rs
@@ -27,7 +27,11 @@ use std::collections::HashMap;
 use std::fs::read_dir;
 use std::path::PathBuf;
 use std::process;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+#[cfg(feature = "async_io")]
+use tokio::sync::Mutex;
+#[cfg(not(feature = "async_io"))]
+use std::sync::Mutex;
 //use std::sync::Arc;
 //use tokio::sync::Mutex;
 use std::thread;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -9,7 +9,11 @@ use pbr::{ProgressBar, Units};
 use rayon::prelude::*;
 use std::collections::HashMap;
 use std::io::Stdout;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+#[cfg(feature = "async_io")]
+use tokio::sync::Mutex;
+#[cfg(not(feature = "async_io"))]
+use std::sync::Mutex;
 use stopwatch::Stopwatch;
 
 pub struct BufferInfo {
@@ -366,6 +370,9 @@ impl Reader {
                 let mut nonces_processed = 0u64;
                 let plot_count = plots.len();
                 'outer: for (i_p, p) in plots.iter().enumerate() {
+#[cfg(feature = "async_io")]
+                    let mut p = p.lock().await;
+#[cfg(not(feature = "async_io"))]
                     let mut p = p.lock().unwrap();
                     if let Err(e) = p.prepare_async(scoop).await {
                         error!(
@@ -381,6 +388,9 @@ impl Reader {
                             sw.restart();
                         }
                         let mut_bs = buffer.get_buffer_for_writing();
+#[cfg(feature = "async_io")]
+                        let mut bs = mut_bs.lock().await;
+#[cfg(not(feature = "async_io"))]
                         let mut bs = mut_bs.lock().unwrap();
                         let (bytes_read, start_nonce, next_plot) = match p.read_async(&mut bs, scoop).await {
                             Ok(x) => x,
@@ -463,6 +473,9 @@ impl Reader {
 
                         match &pb {
                             Some(pb) => {
+#[cfg(feature = "async_io")]
+                                let mut pb = pb.lock().await;
+#[cfg(not(feature = "async_io"))]
                                 let mut pb = pb.lock().unwrap();
                                 pb.add(bytes_read as u64);
                             }
@@ -523,7 +536,12 @@ pub fn check_overlap(drive_id_to_plots: &HashMap<String, Arc<Vec<Mutex<Plot>>>>)
         .values()
         .map(|a| a.iter())
         .flatten()
-        .map(|plot| plot.lock().unwrap().meta.clone())
+        .map(|plot| {
+#[cfg(feature = "async_io")]
+            plot.blocking_lock().meta.clone()
+#[cfg(not(feature = "async_io"))]
+            plot.lock().unwrap().meta.clone()
+        })
         .collect();
     plots
         .par_iter()


### PR DESCRIPTION
## Summary
- support async wake-up via standard IO
- allow async mutex locking in reader, ocl and cpu worker
- gate mutex type on async feature

## Testing
- `cargo build --release --no-default-features --features "neon,async_io"` *(fails: failed to download from crates.io)*