### PR TITLE
Fix async mutex handling

### DIFF
--- a/src/cpu_worker.rs
+++ b/src/cpu_worker.rs
@@ -1,4 +1,14 @@
 use crate::miner::{Buffer, NonceData};
+#[cfg(any(
+    test,
+    not(any(
+        feature = "simd_avx512f",
+        feature = "simd_avx2",
+        feature = "simd_avx",
+        feature = "simd_sse2",
+        feature = "neon",
+    ))
+))]
 use crate::poc_hashing::find_best_deadline_rust;
 use crate::reader::ReadReply;
 use crossbeam_channel::{Receiver, Sender};
@@ -120,6 +130,9 @@ pub fn hash(
         let mut offset: u64 = 0;
 
         let bs = buffer.get_buffer_for_writing();
+#[cfg(feature = "async_io")]
+        let bs = bs.blocking_lock();
+#[cfg(not(feature = "async_io"))]
         let bs = bs.lock().unwrap();
 
         #[cfg(feature = "simd_avx512f")]

--- a/src/miner.rs
+++ b/src/miner.rs
@@ -27,7 +27,11 @@ use std::collections::HashMap;
 use std::fs::read_dir;
 use std::path::PathBuf;
 use std::process;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+#[cfg(feature = "async_io")]
+use tokio::sync::Mutex;
+#[cfg(not(feature = "async_io"))]
+use std::sync::Mutex;
 //use std::sync::Arc;
 //use tokio::sync::Mutex;
 use std::thread;


### PR DESCRIPTION
## Summary
- handle wakeup locking with blocking_lock when async feature is enabled
- return meta in check_overlap via cfg blocks
- only import `find_best_deadline_rust` when necessary

## Testing
- `cargo check --locked --offline --no-default-features --features "neon,async_io"` *(fails: no matching package named `bytes`)*