### PR TITLE
Fix build for async_io and NEON

### DIFF
--- a/src/cpu_worker.rs
+++ b/src/cpu_worker.rs
@@ -1,14 +1,4 @@
 use crate::miner::{Buffer, NonceData};
-#[cfg(any(
-    test,
-    not(any(
-        feature = "simd_avx512f",
-        feature = "simd_avx2",
-        feature = "simd_avx",
-        feature = "simd_sse2",
-        feature = "neon",
-    ))
-))]
 use crate::poc_hashing::find_best_deadline_rust;
 use crate::reader::ReadReply;
 use crossbeam_channel::{Receiver, Sender};

--- a/src/plot.rs
+++ b/src/plot.rs
@@ -10,6 +10,8 @@ use tokio::fs::File as TokioFile;
 use std::fs::File as TokioFile;
 #[cfg(feature = "async_io")]
 use tokio::io::{AsyncReadExt, AsyncSeekExt};
+#[cfg(feature = "async_io")]
+use std::io::Seek;
 use std::io;
 use std::io::{SeekFrom};
 #[cfg(not(feature = "async_io"))]


### PR DESCRIPTION
## Summary
- always import `find_best_deadline_rust` so NEON builds compile
- support `async_io` mutex usage in miner
- add missing Seek trait import when using async I/O

## Testing
- `cargo check` *(fails: failed to download config.json)*
- `cargo test` *(fails: failed to download config.json)*