### PR TITLE
Fix build for async_io and NEON

### DIFF
--- a/src/cpu_worker.rs
+++ b/src/cpu_worker.rs
@@ -1,14 +1,4 @@
 use crate::miner::{Buffer, NonceData};
-#[cfg(any(
-    test,
-    not(any(
-        feature = "simd_avx512f",
-        feature = "simd_avx2",
-        feature = "simd_avx",
-        feature = "simd_sse2",
-        feature = "neon",
-    ))
-))]
 use crate::poc_hashing::find_best_deadline_rust;
 use crate::reader::ReadReply;
 use crossbeam_channel::{Receiver, Sender};

--- a/src/miner.rs
+++ b/src/miner.rs
@@ -236,6 +236,9 @@ fn scan_plots(
         .drain()
         .map(|(drive_id, mut plots)| {
             plots.sort_by_key(|p| {
+                #[cfg(feature = "async_io")]
+                let p = p.blocking_lock();
+                #[cfg(not(feature = "async_io"))]
                 let p = p.lock().unwrap();
                 let m = std::fs::metadata(&p.path).unwrap();
                 -FileTime::from_last_modification_time(&m).unix_seconds()
@@ -509,6 +512,9 @@ impl Miner {
                         let mining_info = request_handler.get_mining_info();
                         match mining_info.await {
                             Ok(mining_info) => {
+                                #[cfg(feature = "async_io")]
+                                let mut state = state.lock().await;
+                                #[cfg(not(feature = "async_io"))]
                                 let mut state = state.lock().unwrap();
                                 state.first = false;
                                 if state.outage {
@@ -517,6 +523,15 @@ impl Miner {
                                 }
                                 if mining_info.generation_signature != state.generation_signature {
                                     state.update_mining_info(&mining_info);
+                                    #[cfg(feature = "async_io")]
+                                    reader.lock().await.start_reading(
+                                        mining_info.height,
+                                        state.block,
+                                        mining_info.base_target,
+                                        state.scoop,
+                                        &Arc::new(state.generation_signature_bytes),
+                                    );
+                                    #[cfg(not(feature = "async_io"))]
                                     reader.lock().unwrap().start_reading(
                                         mining_info.height,
                                         state.block,
@@ -530,11 +545,17 @@ impl Miner {
                                     && state.sw.elapsed_ms() > wakeup_after
                                 {
                                     info!("HDD, wakeup!");
+                                    #[cfg(feature = "async_io")]
+                                    reader.lock().await.wakeup();
+                                    #[cfg(not(feature = "async_io"))]
                                     reader.lock().unwrap().wakeup();
                                     state.sw.restart();
                                 }
                             }
                             _ => {
+                                #[cfg(feature = "async_io")]
+                                let mut state = state.lock().await;
+                                #[cfg(not(feature = "async_io"))]
                                 let mut state = state.lock().unwrap();
                                 if state.first {
                                     error!(
@@ -577,78 +598,84 @@ impl Miner {
         self.executor.clone().spawn(
             ReceiverStream::new(self.rx_nonce_data)
                 .for_each(move |nonce_data| {
-                    let mut state = state.lock().unwrap();
+                    let state = state.clone();
+                    let request_handler = request_handler.clone();
+                    async move {
+                        #[cfg(feature = "async_io")]
+                        let mut state = state.lock().await;
+                        #[cfg(not(feature = "async_io"))]
+                        let mut state = state.lock().unwrap();
 
-                    let deadline = nonce_data.deadline / nonce_data.base_target;
-                    if state.height == nonce_data.height {
-                        let best_deadline = *state
-                            .account_id_to_best_deadline
-                            .get(&nonce_data.account_id)
-                            .unwrap_or(&u64::MAX);
-                        if best_deadline > deadline
-                            && deadline
-                                < min(
-                                    state.server_target_deadline,
-                                    *(account_id_to_target_deadline
-                                        .get(&nonce_data.account_id)
-                                        .unwrap_or(&target_deadline)),
-                                )
-                        {
-                            state
+                        let deadline = nonce_data.deadline / nonce_data.base_target;
+                        if state.height == nonce_data.height {
+                            let best_deadline = *state
                                 .account_id_to_best_deadline
-                                .insert(nonce_data.account_id, deadline);
-                            
-                            if inner_submit_only_best {
-                                best_nonce_data = nonce_data.clone();
-                            }
-                            else {
-                                request_handler.submit_nonce(
-                                    nonce_data.account_id,
-                                    nonce_data.nonce,
-                                    nonce_data.height,
-                                    nonce_data.block,
-                                    nonce_data.deadline,
-                                    deadline,
-                                    state.generation_signature_bytes,
-                                );
-                            }
-                        }
-
-                        if nonce_data.reader_task_processed {
-                            state.processed_reader_tasks += 1;
-                            if state.processed_reader_tasks == reader_task_count {
-                                info!(
-                                    "{: <80}",
-                                    format!(
-                                        "round finished: roundtime={}ms, speed={:.2}MiB/s",
-                                        state.sw.elapsed_ms(),
-                                        total_size as f64 * 1000.0
-                                            / 1024.0
-                                            / 1024.0
-                                            / state.sw.elapsed_ms() as f64
+                                .get(&nonce_data.account_id)
+                                .unwrap_or(&u64::MAX);
+                            if best_deadline > deadline
+                                && deadline
+                                    < min(
+                                        state.server_target_deadline,
+                                        *(account_id_to_target_deadline
+                                            .get(&nonce_data.account_id)
+                                            .unwrap_or(&target_deadline)),
                                     )
-                                );
+                            {
+                                state
+                                    .account_id_to_best_deadline
+                                    .insert(nonce_data.account_id, deadline);
 
-                                // Submit now our best one, if configured that way
-                                if best_nonce_data.height == state.height {
-                                    let deadline = best_nonce_data.deadline / best_nonce_data.base_target;
+                                if inner_submit_only_best {
+                                    best_nonce_data = nonce_data.clone();
+                                } else {
                                     request_handler.submit_nonce(
-                                        best_nonce_data.account_id,
-                                        best_nonce_data.nonce,
-                                        best_nonce_data.height,
-                                        best_nonce_data.block,
-                                        best_nonce_data.deadline,
+                                        nonce_data.account_id,
+                                        nonce_data.nonce,
+                                        nonce_data.height,
+                                        nonce_data.block,
+                                        nonce_data.deadline,
                                         deadline,
                                         state.generation_signature_bytes,
                                     );
                                 }
+                            }
 
-                                state.sw.restart();
-                                state.scanning = false;
+                            if nonce_data.reader_task_processed {
+                                state.processed_reader_tasks += 1;
+                                if state.processed_reader_tasks == reader_task_count {
+                                    info!(
+                                        "{: <80}",
+                                        format!(
+                                            "round finished: roundtime={}ms, speed={:.2}MiB/s",
+                                            state.sw.elapsed_ms(),
+                                            total_size as f64 * 1000.0
+                                                / 1024.0
+                                                / 1024.0
+                                                / state.sw.elapsed_ms() as f64
+                                        )
+                                    );
+
+                                    // Submit now our best one, if configured that way
+                                    if best_nonce_data.height == state.height {
+                                        let deadline =
+                                            best_nonce_data.deadline / best_nonce_data.base_target;
+                                        request_handler.submit_nonce(
+                                            best_nonce_data.account_id,
+                                            best_nonce_data.nonce,
+                                            best_nonce_data.height,
+                                            best_nonce_data.block,
+                                            best_nonce_data.deadline,
+                                            deadline,
+                                            state.generation_signature_bytes,
+                                        );
+                                    }
+
+                                    state.sw.restart();
+                                    state.scanning = false;
+                                }
                             }
                         }
                     }
-                    futures_util::future::ready(())
                 }),
         );
         loop {

--- a/src/plot.rs
+++ b/src/plot.rs
@@ -10,6 +10,8 @@ use tokio::fs::File as TokioFile;
 use std::fs::File as TokioFile;
 #[cfg(feature = "async_io")]
 use tokio::io::{AsyncReadExt, AsyncSeekExt};
+#[cfg(feature = "async_io")]
+use std::io::Seek;
 use std::io;
 use std::io::{SeekFrom};
 #[cfg(not(feature = "async_io"))]


### PR DESCRIPTION
## Summary
- always import `find_best_deadline_rust` so NEON builds compile
- support `async_io` mutex usage in miner
- add missing Seek trait import when using async I/O
- make nonce handling closure async when using locks

## Testing
- `cargo check --offline` *(fails: no matching package named `bytes` found)*