### PR TITLE
Fix async lock call within for_each

### DIFF
--- a/src/miner.rs
+++ b/src/miner.rs
@@ -598,10 +598,13 @@ impl Miner {
         self.executor.clone().spawn(
             ReceiverStream::new(self.rx_nonce_data)
                 .for_each(move |nonce_data| {
-                    #[cfg(feature = "async_io")]
-                    let mut state = state.lock().await;
-                    #[cfg(not(feature = "async_io"))]
-                    let mut state = state.lock().unwrap();
+                    let state = state.clone();
+                    let request_handler = request_handler.clone();
+                    async move {
+                        #[cfg(feature = "async_io")]
+                        let mut state = state.lock().await;
+                        #[cfg(not(feature = "async_io"))]
+                        let mut state = state.lock().unwrap();
 
                     let deadline = nonce_data.deadline / nonce_data.base_target;
                     if state.height == nonce_data.height {
@@ -672,7 +675,6 @@ impl Miner {
                             }
                         }
                     }
-                    futures_util::future::ready(())
                 }),
         );
         loop {


### PR DESCRIPTION
## Summary
- fix `await` usage by wrapping for_each closure in an async block

## Testing
- `cargo check` *(fails: failed to download from `https://index.crates.io/config.json`)*