### PR TITLE
Fix async for_each move capture

### DIFF
--- a/src/cpu_worker.rs
+++ b/src/cpu_worker.rs
@@ -1,4 +1,14 @@
 use crate::miner::{Buffer, NonceData};
+#[cfg(any(
+    test,
+    not(any(
+        feature = "simd_avx512f",
+        feature = "simd_avx2",
+        feature = "simd_avx",
+        feature = "simd_sse2",
+        feature = "neon",
+    ))
+))]
 use crate::poc_hashing::find_best_deadline_rust;
 use crate::reader::ReadReply;
 use crossbeam_channel::{Receiver, Sender};


### PR DESCRIPTION
## Summary
- fix move capture errors in async nonce for_each loop
- conditionally import `find_best_deadline_rust`

## Testing
- `cargo check --locked --offline` *(fails: no matching package named `bytes` found)*