### PR TITLE
Fix import for fallback hashing

### DIFF
--- a/src/cpu_worker.rs
+++ b/src/cpu_worker.rs
@@ -1,12 +1,12 @@
 use crate::miner::{Buffer, NonceData};
 #[cfg(any(
     test,
+    feature = "neon",
     not(any(
         feature = "simd_avx512f",
         feature = "simd_avx2",
         feature = "simd_avx",
         feature = "simd_sse2",
-        feature = "neon",
     ))
 ))]
 use crate::poc_hashing::find_best_deadline_rust;


### PR DESCRIPTION
## Summary
- include `find_best_deadline_rust` when building with `neon`

## Testing
- `cargo test --no-run` *(fails: failed to download from `https://index.crates.io`)*
- `cargo check --locked --offline` *(fails: no matching package named `bytes` found)*