### PR TITLE
Add capacity refresh option

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ automatically disabled for plot directories residing on USB drives.
 default of 4&nbsp;MiB works well for most drives but you may lower it for slow
 USB devices.
 
+`capacity_check_interval` defines how often the miner rescans the plot
+directories to update its total capacity. The default of 6&nbsp;hours is a good
+balance for most setups.
+
 ### Running
 Be sure to have the config file on the same folder of your binary.</br>
 

--- a/config.yaml
+++ b/config.yaml
@@ -33,6 +33,7 @@ target_deadline: 31536000             # default 31536000 (1 year)
 # 1796535821016683299: 55555555
 
 get_mining_info_interval: 3000        # default 3000ms
+capacity_check_interval: 21600        # default 21600s
 timeout: 5000                         # default 5000ms
 send_proxy_details: false              # default false
 submit_only_best: true                # default true

--- a/src/config.rs
+++ b/src/config.rs
@@ -84,6 +84,9 @@ pub struct Cfg {
     #[serde(default = "default_additional_headers")]
     pub additional_headers: HashMap<String, String>,
 
+    #[serde(default = "default_capacity_check_interval")]
+    pub capacity_check_interval: u64,
+
     #[serde(default = "default_console_log_level")]
     pub console_log_level: String,
 
@@ -210,6 +213,10 @@ fn default_timeout() -> u64 {
 
 fn default_send_proxy_details() -> bool {
     false
+}
+
+fn default_capacity_check_interval() -> u64 {
+    21600
 }
 
 fn default_additional_headers() -> HashMap<String, String> {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -172,6 +172,19 @@ impl Reader {
         }
     }
 
+    pub fn update_plots(
+        &mut self,
+        drive_id_to_plots: HashMap<String, Arc<Vec<Mutex<Plot>>>>,
+        total_size: u64,
+        benchmark: bool,
+    ) {
+        if !benchmark {
+            check_overlap(&drive_id_to_plots);
+        }
+        self.drive_id_to_plots = drive_id_to_plots;
+        self.total_size = total_size;
+    }
+
     #[cfg(not(feature = "async_io"))]
     fn create_read_task(
         &self,

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -150,6 +150,16 @@ impl RequestHandler {
             error!("can't send submission params: {}", e);
         }
     }
+
+    #[cfg(feature = "async_io")]
+    pub async fn update_capacity(&mut self, total_size_gb: usize) {
+        self.client.update_capacity(total_size_gb).await;
+    }
+
+    #[cfg(not(feature = "async_io"))]
+    pub fn update_capacity(&mut self, total_size_gb: usize) {
+        self.client.update_capacity(total_size_gb);
+    }
 }
 
 fn log_deadline_mismatch(


### PR DESCRIPTION
## Summary
- add `capacity_check_interval` to config and docs
- refresh plot capacity periodically and update `X-Capacity` header
- implement dynamic capacity updates for `Client` and `RequestHandler`

## Testing
- `cargo test` *(fails: failed to download crates)*