### PR TITLE
Remove commented uses in miner.rs

### DIFF
--- a/src/miner.rs
+++ b/src/miner.rs
@@ -32,8 +32,6 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 #[cfg(not(feature = "async_io"))]
 use std::sync::Mutex;
-//use std::sync::Arc;
-//use tokio::sync::Mutex;
 use std::thread;
 use std::u64;
 use stopwatch::Stopwatch;


### PR DESCRIPTION
## Summary
- remove unused commented `use std::sync::Arc` and `use tokio::sync::Mutex` lines

## Testing
- `cargo test` *(fails: failed to download crates index)*