### PR TITLE
Fix unmatched parentheses in miner struct init

### DIFF
--- a/src/miner.rs
+++ b/src/miner.rs
@@ -473,7 +473,7 @@ impl Miner {
                 cfg.show_drive_stats,
                 cfg.cpu_thread_pinning,
                 cfg.benchmark_cpu(),
-            )),
+            ))),
             rx_nonce_data,
             target_deadline: cfg.target_deadline,
             account_id_to_target_deadline: cfg.account_id_to_target_deadline,
@@ -485,7 +485,7 @@ impl Miner {
                 cfg.send_proxy_details,
                 cfg.additional_headers,
                 executor.clone(),
-            )),
+            ))),
             state: Arc::new(Mutex::new(State::new())),
             // floor at 1s to protect servers
             get_mining_info_interval: max(1000, cfg.get_mining_info_interval),


### PR DESCRIPTION
## Summary
- fix mismatched closing delimiter in `src/miner.rs`

## Testing
- `cargo test` *(fails: failed to download crates)*