### PR TITLE
Fix parameter type for Plot::new

### DIFF
--- a/src/miner.rs
+++ b/src/miner.rs
@@ -208,10 +208,10 @@ fn scan_plots(
         let is_usb = bus_type.to_lowercase() == "usb" || bus_type.to_lowercase() == "removable";
         let mut num_plots = 0;
         let mut local_capacity: u64 = 0;
-        for file in read_dir(plot_dir).unwrap() {
-            let file = &file.unwrap().path();
+        for entry in read_dir(plot_dir).unwrap() {
+            let file = entry.unwrap().path();
 
-            if let Ok(p) = Plot::new(file, use_direct_io && !is_usb, dummy) {
+            if let Ok(p) = Plot::new(&file, use_direct_io && !is_usb, dummy) {
                 let drive_id = get_device_id(&file.to_str().unwrap().to_string());
                 let plots = drive_id_to_plots.entry(drive_id).or_insert(Vec::new());
 

--- a/src/plot.rs
+++ b/src/plot.rs
@@ -104,7 +104,7 @@ cfg_if! {
 }
 
 impl Plot {
-    pub fn new(path: &PathBuf, mut use_direct_io: bool, dummy: bool) -> Result<Plot, Box<dyn Error>> {
+    pub fn new(path: &Path, mut use_direct_io: bool, dummy: bool) -> Result<Plot, Box<dyn Error>> {
         if !path.is_file() {
             return Err(From::from(format!(
                 "{} is not a file",
@@ -153,7 +153,7 @@ impl Plot {
             use_direct_io = false;
         }
 
-        let file_path = path.clone().into_os_string().into_string().unwrap();
+        let file_path = path.to_path_buf().into_os_string().into_string().unwrap();
         Ok(Plot {
             meta: Meta {
                 account_id,


### PR DESCRIPTION
## Summary
- accept `&Path` instead of `&PathBuf` in `Plot::new`
- adjust miner path iteration accordingly

## Testing
- `cargo test --quiet` *(fails: failed to download from crates.io)*