### PR TITLE
Enable automatic storage scanning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ url = { version = "2", features = ["serde"] }
 page_size = "0.6.0"
 reqwest = { version = "0.12.15", default-features = false, features = ["rustls-tls"] }
 bytes = "1.10.1"
+walkdir = "2"
 
 
 [target.'cfg(windows)'.dependencies]


### PR DESCRIPTION
## Summary
- add walkdir dependency for recursive directory scanning
- implement `get_mount_points` in utils for Unix and Windows
- recursively scan all mount points plus configured dirs
- update capacity refresh to rescan available storage
- exclude root directory when searching mount points

## Testing
- `cargo test --no-run` *(fails: Could not connect to server)*