### PR TITLE
Add Home tab to miner UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,10 @@ For Linux run it with the folliwing command:</br>
 
 For an optional graphical interface, run `miner_ui.py` with Python 3. The UI now
 uses the [CustomTkinter](https://github.com/TomSchimansky/CustomTkinter)
-framework to provide a modern dark theme with blue accents. Two tabs are
-available: a raw YAML editor and an **Options** tab that lets you modify
-configuration values using form fields. Install the required packages first:
+framework to provide a modern dark theme with blue accents. Four tabs are
+available: **Home**, a raw YAML editor (**Config**), an **Options** tab for
+editing fields and a **Logs** tab to monitor output. Install the required
+packages first:
 ```bash
 pip install customtkinter pyyaml
 ```

--- a/miner_ui.py
+++ b/miner_ui.py
@@ -23,9 +23,27 @@ class MinerUI:
         self.tabview = ctk.CTkTabview(master)
         self.tabview.pack(fill="both", expand=True)
 
+        self.home_tab = self.tabview.add("Home")
         self.config_tab = self.tabview.add("Config")
         self.options_tab = self.tabview.add("Options")
         self.logs_tab = self.tabview.add("Logs")
+
+        # Home tab content
+        logo_path = os.path.join(os.path.dirname(__file__), "signum_logo.png")
+        if os.path.exists(logo_path):
+            self.logo_image = tk.PhotoImage(file=logo_path)
+            ctk.CTkLabel(self.home_tab, image=self.logo_image, text="").pack(pady=10)
+        ctk.CTkLabel(
+            self.home_tab,
+            text="Signum — The sustainable blockchain",
+            font=("Arial", 20),
+        ).pack(pady=(0, 10))
+        ctk.CTkLabel(
+            self.home_tab,
+            text="Join the green revolution of decentralized computing — mine with purpose. Mine with Signum.",
+            wraplength=600,
+            justify="center",
+        ).pack(pady=10)
 
         path_frame = ctk.CTkFrame(self.config_tab, fg_color="transparent")
         path_frame.pack(fill="x", padx=5, pady=5)


### PR DESCRIPTION
## Summary
- add a Home tab in the Python UI
- show Signum description and optional logo
- document the four UI tabs

## Testing
- `cargo test --quiet` *(fails: Could not connect to server)*