### PR TITLE
Fix UI image loading warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ available: **Home**, a raw YAML editor (**Config**), an **Options** tab for
 editing fields and a **Logs** tab to monitor output. Install the required
 packages first:
 ```bash
-pip install customtkinter pyyaml
+pip install customtkinter pyyaml pillow
 ```
 You can then edit `config.yaml`, start or stop the miner and monitor its log
 output in a more user friendly window.

--- a/miner_ui.py
+++ b/miner_ui.py
@@ -6,6 +6,7 @@ import tkinter as tk
 from tkinter import filedialog, messagebox
 import customtkinter as ctk
 import yaml
+from PIL import Image
 
 class MinerUI:
     def __init__(self, master):
@@ -31,7 +32,8 @@ class MinerUI:
         # Home tab content
         logo_path = os.path.join(os.path.dirname(__file__), "signum_logo.png")
         if os.path.exists(logo_path):
-            self.logo_image = tk.PhotoImage(file=logo_path)
+            image = Image.open(logo_path)
+            self.logo_image = ctk.CTkImage(light_image=image, dark_image=image)
             ctk.CTkLabel(self.home_tab, image=self.logo_image, text="").pack(pady=10)
         ctk.CTkLabel(
             self.home_tab,


### PR DESCRIPTION
## Summary
- allow logo scaling by using `CTkImage`
- import Pillow's `Image` for UI
- document extra Python dependency for the GUI

## Testing
- `cargo test` *(fails: could not connect to server)*