### PR TITLE
Add automated setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ available: **Home**, a raw YAML editor (**Config**), an **Options** tab for
 editing fields and a **Logs** tab to monitor output. Install the required
 packages first:
 ```bash
-pip install customtkinter pyyaml
+pip install -r requirements.txt
 ```
 You can then edit `config.yaml`, start or stop the miner and monitor its log
 output in a more user friendly window.
@@ -129,6 +129,9 @@ curl https://sh.rustup.rs -sSf | sh
 # Clone the repository
 git clone https://github.com/signum-network/signum-miner
 cd signum-miner
+# Or run the automated setup which installs requirements and builds
+python3 setup.py
+
 
 # decide on features to run/build:
 simd: support for SSE2, AVX, AVX2 and AVX512F (x86_cpu)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+customtkinter
+PyYAML

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,53 @@
+import os
+import platform
+import subprocess
+import sys
+
+
+def run(cmd, shell=False):
+    print('Running:', ' '.join(cmd) if isinstance(cmd, list) else cmd)
+    try:
+        if shell:
+            subprocess.check_call(cmd, shell=True)
+        else:
+            subprocess.check_call(cmd)
+    except subprocess.CalledProcessError as e:
+        sys.exit(e.returncode)
+
+
+def ensure_rust():
+    try:
+        subprocess.check_call(['cargo', '--version'])
+        subprocess.check_call(['rustc', '--version'])
+    except Exception:
+        print('Rust not found. Installing via rustup...')
+        if platform.system() == 'Windows':
+            rustup = 'https://win.rustup.rs/'
+            run(['powershell', '-Command', f"iwr -useb {rustup} | iex"], shell=False)
+        else:
+            run('curl https://sh.rustup.rs -sSf | sh -s -- -y', shell=True)
+        # load cargo env
+        cargo_env = os.path.expanduser('~/.cargo/env')
+        if os.path.exists(cargo_env):
+            with open(cargo_env) as f:
+                exec(f.read(), dict(__file__=cargo_env))
+
+
+def install_python_deps():
+    if os.path.exists('requirements.txt'):
+        run([sys.executable, '-m', 'pip', 'install', '-r', 'requirements.txt'])
+
+
+def build_project():
+    run(['cargo', 'build', '--release'])
+
+
+def main():
+    ensure_rust()
+    install_python_deps()
+    build_project()
+    print('\nAll dependencies installed and project built.')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add requirements file for Python GUI
- provide cross-platform `setup.py` script to install dependencies and build
- document automated setup workflow in README

## Testing
- `cargo test` *(fails: Could not update crates.io index)*
- `python3 setup.py` *(fails: no network access to install dependencies)*