### PR TITLE
Clarify binary name for GUI and summarize branch changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ python3 miner_ui.py
 
 The CustomTkinter based UI works on Linux, macOS and Windows as long as Python 3
 is available and the `signum-miner` binary is in the same directory.
+Make sure the compiled miner binary is named **exactly** `signum-miner`,
+otherwise the UI will fail to launch it.
 
 ---
 

--- a/miner_ui.py
+++ b/miner_ui.py
@@ -112,6 +112,8 @@ class MinerUI:
             messagebox.showerror("Error", f"Failed to save config: {e}")
 
     def start_miner(self):
+        # The UI expects the miner binary to be named "signum-miner". Ensure the
+        # compiled binary uses this exact name or launching will fail.
         cmd = [os.path.join('.', 'signum-miner'), '-c', self.config_path.get()]
         try:
             self.process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)


### PR DESCRIPTION
## Summary
- clarify in README that the GUI expects the binary to be named exactly `signum-miner`
- add inline comment in `miner_ui.py` about the binary name requirement

## Testing
- `cargo test` *(fails: Could not connect to server)*