### PR TITLE
Fix nonce offset alignment

### DIFF
--- a/src/plot.rs
+++ b/src/plot.rs
@@ -215,7 +215,9 @@ pub fn prepare(&mut self, scoop: u32) -> io::Result<u64> {
     pub fn read(&mut self, bs: &mut Vec<u8>, scoop: u32) -> Result<(usize, u64, bool), io::Error> {
         let read_offset = self.read_offset;
         let buffer_cap = bs.capacity();
-        let start_nonce = self.meta.start_nonce + self.read_offset / 64;
+        let start_nonce = self.meta.start_nonce
+            + u64::from(scoop) * self.meta.nonces
+            + self.read_offset / 64;
 
         let (bytes_to_read, finished) =
             if read_offset as usize + buffer_cap >= (SCOOP_SIZE * self.meta.nonces) as usize {
@@ -261,7 +263,9 @@ pub fn prepare(&mut self, scoop: u32) -> io::Result<u64> {
     ) -> Result<(usize, u64, bool), io::Error> {
         let read_offset = self.read_offset;
         let buffer_cap = bs.capacity();
-        let start_nonce = self.meta.start_nonce + self.read_offset / 64;
+        let start_nonce = self.meta.start_nonce
+            + u64::from(scoop) * self.meta.nonces
+            + self.read_offset / 64;
 
         let (bytes_to_read, finished) = if read_offset as usize + buffer_cap
             >= (SCOOP_SIZE * self.meta.nonces) as usize


### PR DESCRIPTION
## Summary
- correct nonce offset calculation for aligned reads

## Testing
- `cargo check` *(fails: could not fetch crates)*